### PR TITLE
Fix for adding a migration

### DIFF
--- a/tinano/lib/api/database.dart
+++ b/tinano/lib/api/database.dart
@@ -25,7 +25,7 @@ abstract class TinanoDatabase {
   /// Should only be used by the generated code
   _OnCreate onCreate;
   /// Should only be used by the generated code
-  List<SchemaMigrationWithVersion> migrations;
+  List<SchemaMigrationWithVersion> migrations = [];
 
   /// Creates a new instance of the database class but with the executor
   /// replaced to the one specified in the parameter. Useful as we can use


### PR DESCRIPTION
Before tried to add a migration to a not initialised list (initialised with `null`). Fixed that by actually creating a growable list, where future migrations can get added to.

Resolves #6.